### PR TITLE
add id module

### DIFF
--- a/src/youid/id.gleam
+++ b/src/youid/id.gleam
@@ -1,0 +1,48 @@
+//// This module provides the little bit of boilerplate you're liekly 
+//// to want to write around your UUIDs.
+//// It provides a type `Id` which:
+//// 1. is a wrapper around a UUID
+//// 2. has a phantom type to ensure that the ID is used in the correct context.
+//// 3. provides a prefix to the ID.
+//// 4. provides a function to generate IDs of the specified type
+//// 
+//// Let's say you have a type `User` which you want to provide IDs for. 
+//// Just set up your function for generating new ids like so
+//// 
+//// ```gleam
+//// // Your Type
+//// pub type User
+////
+//// // Your specification for creating new IDs
+//// pub fn new_user_id() -> Id(User) {
+////   id.format(prefixed_with: "orgname-user")()
+//// }
+//// ```
+
+import youid/uuid.{type Uuid}
+
+/// A high level wrapper around a Uuid with some common functionality.
+/// 1. a phantom type to ensure that the ID is used in the correct context.
+/// 2. provide a prefix to the ID.
+pub opaque type Id(a) {
+  Id(String)
+}
+
+/// Get out the inner string of the ID.
+pub fn to_string(id: Id(a)) -> String {
+  let Id(value) = id
+  value
+}
+
+/// A function which will generate IDs of the specified type
+pub type IdGenerator(a) =
+  fn() -> Id(a)
+
+/// Create a new ID generator which will generate IDs with the specified prefix.
+///
+pub fn format(prefixed_with prefix: String) -> IdGenerator(a) {
+  fn() {
+    let id = uuid.v4_string()
+    Id(prefix <> "-" <> id)
+  }
+}

--- a/test/youid_test.gleam
+++ b/test/youid_test.gleam
@@ -1,6 +1,8 @@
 import youid/uuid
+import youid/id.{type Id, type IdGenerator}
 import gleeunit/should
 import gleeunit
+import gleam/string
 
 pub fn main() {
   gleeunit.main()
@@ -129,4 +131,30 @@ pub fn v5_dns_namespace_test() {
 pub fn v5_dont_crash_on_bad_name_test() {
   uuid.v5(uuid.dns_uuid(), <<1:1>>)
   |> should.equal(Error(Nil))
+}
+
+//
+// Id tests
+//
+
+pub type User
+
+pub fn new_user_id() -> Id(User) {
+  id.format(prefixed_with: "orgname-user")()
+}
+
+pub fn id_usage_test() {
+  let user_1 = new_user_id()
+
+  user_1
+  |> id.to_string
+  |> string.starts_with("orgname-user-")
+  |> should.equal(True)
+
+  let backing_id =
+    user_1
+    |> id.to_string
+    |> string.drop_left(13)
+  uuid.from_string(backing_id)
+  |> should.be_ok
 }


### PR DESCRIPTION
Adds an ID module with some common boilerplate for UUID backed Ids. The gist of the functionality is
```gleam
// This would be a user defined function for their `User` type
pub fn new_user_id() -> Id(User) {
  id.format(prefixed_with: "orgname-user")()
}
```
It's purpose is to make id best practices (phantom types and prefixes but maybe more later) quick and easy to set up for your types.