### PR TITLE
Support for UUIDv7 draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,16 @@ pub fn main() {
 }
 ```
 
-Spec conformant UUID v1, v3, v4, and v5 generation.
+Spec conformant UUID v1, v3, v4, v5, and v7 generation.
 
-Spec conformant UUID decoding for v1, v2, v3, v4, and v5.
+Spec conformant UUID decoding for v1, v2, v3, v4, v5, and v7.
 
-Draft spec conformant UUID v7 generation and decoding.
-
-Spec: [https://www.ietf.org/rfc/rfc4122.txt](https://www.ietf.org/rfc/rfc4122.txt)
-
-Version 7 draft spec: [https://www.ietf.org/archive/id/draft-peabody-dispatch-new-uuid-format-04.html#name-uuid-version-7](https://www.ietf.org/archive/id/draft-peabody-dispatch-new-uuid-format-04.html#name-uuid-version-7)
+Spec: [https://www.ietf.org/rfc/rfc9562.txt](https://www.ietf.org/rfc/rfc9562.txt)
 
 Wikipedia: [https://en.wikipedia.org/wiki/uuid](https://en.wikipedia.org/wiki/uuid)
 
 Unless you have a specific reason otherwise, you probably either want the
-random v4 or the time-based v1 version.
+random v4 or the time-based v1 or v7 versions.
 
 Currently this library only works on the Erlang target as the JavaScript target
 does not yet support non-byte aligned bit arrays.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ Spec conformant UUID v1, v3, v4, and v5 generation.
 
 Spec conformant UUID decoding for v1, v2, v3, v4, and v5.
 
+Draft spec conformant UUID v7 generation and decoding.
+
 Spec: [https://www.ietf.org/rfc/rfc4122.txt](https://www.ietf.org/rfc/rfc4122.txt)
+
+Version 7 draft spec: [https://www.ietf.org/archive/id/draft-peabody-dispatch-new-uuid-format-04.html#name-uuid-version-7](https://www.ietf.org/archive/id/draft-peabody-dispatch-new-uuid-format-04.html#name-uuid-version-7)
 
 Wikipedia: [https://en.wikipedia.org/wiki/uuid](https://en.wikipedia.org/wiki/uuid)
 

--- a/src/youid/uuid.gleam
+++ b/src/youid/uuid.gleam
@@ -343,10 +343,16 @@ pub fn time(uuid: Uuid) -> Int {
 }
 
 /// Determine the time a UUID was created with Unix Epoch
-/// This is only relevant to a V1 UUID
+/// This is only relevant to V1 and V7 UUIDs
 /// Value is the number of micro seconds since Unix Epoch
 pub fn time_posix_microsec(uuid: Uuid) -> Int {
-  { time(uuid) - nanosec_intervals_offset } / nanosec_intervals_factor
+  case version(uuid) {
+    V7 -> {
+      let assert <<t:48, _:80>> = uuid.value
+      t * 1000
+    }
+    _ -> { time(uuid) - nanosec_intervals_offset } / nanosec_intervals_factor
+  }
 }
 
 /// Determine the clock sequence of a UUID
@@ -380,11 +386,18 @@ pub fn node(uuid: Uuid) -> String {
 }
 
 /// Determine the time a UUID was created with Unix Epoch
-/// This is only relevant to a V7 UUID
-/// Value is the number of milliseconds since Unix Epoch
-pub fn time_posix_millisecond(uuid: Uuid) -> Int {
-  let assert <<t:48, _:80>> = uuid.value
-  t
+/// This is only relevant to V1 and V7 UUIDs
+/// Value is the number of milli seconds since Unix Epoch
+pub fn time_posix_millisec(uuid: Uuid) -> Int {
+  case version(uuid) {
+    V1 ->
+      { { time(uuid) - nanosec_intervals_offset } / nanosec_intervals_factor }
+      / 1000
+    _ -> {
+      let assert <<t:48, _:80>> = uuid.value
+      t
+    }
+  }
 }
 
 /// Convert a UUID to a standard string

--- a/test/youid_test.gleam
+++ b/test/youid_test.gleam
@@ -22,6 +22,13 @@ pub fn v4_from_string_test() {
   |> should.equal(uuid.V4)
 }
 
+pub fn v7_from_string_test() {
+  let assert Ok(uuid) = uuid.from_string("018ed16d-0f82-7d38-a8ad-31f11b97d10c")
+  uuid
+  |> uuid.version
+  |> should.equal(uuid.V7)
+}
+
 pub fn unknown_version_test() {
   let assert Ok(uuid) = uuid.from_string("16b53fc5-f9a7-0f6b-8180-399ab0986250")
   uuid
@@ -303,4 +310,28 @@ pub fn v5_from_bit_array_test() {
   |> uuid.from_bit_array()
   |> should.be_ok()
   |> should.equal(uuid)
+}
+
+//
+// V7 Tests
+//
+pub fn v7_custom_timestamp_test() {
+  let uuid = uuid.custom_v7(1_712_910_566)
+  uuid.time_posix_millisecond(uuid)
+  |> should.equal(1_712_910_566)
+}
+
+pub fn v7_can_validate_self_test() {
+  let assert Ok(uuid) =
+    uuid.v7()
+    |> uuid.to_string()
+    |> uuid.from_string()
+
+  uuid
+  |> uuid.version
+  |> should.equal(uuid.V7)
+
+  uuid
+  |> uuid.variant
+  |> should.equal(uuid.Rfc4122)
 }

--- a/test/youid_test.gleam
+++ b/test/youid_test.gleam
@@ -153,6 +153,18 @@ pub fn v1_from_bit_array_test() {
   |> should.equal(uuid)
 }
 
+pub fn v1_posix_time_test() {
+  let assert Ok(uuid) = uuid.from_string("49cac37c-310b-11eb-adc1-0242ac120002")
+
+  uuid
+  |> uuid.time_posix_microsec()
+  |> should.equal(1_606_521_011_735_846)
+
+  uuid
+  |> uuid.time_posix_millisec()
+  |> should.equal(1_606_521_011_735)
+}
+
 //
 // V3 Tests
 //
@@ -319,8 +331,12 @@ pub fn v5_from_bit_array_test() {
 //
 pub fn v7_custom_timestamp_test() {
   let uuid = uuid.custom_v7(1_712_910_566)
-  uuid.time_posix_millisecond(uuid)
+
+  uuid.time_posix_millisec(uuid)
   |> should.equal(1_712_910_566)
+
+  uuid.time_posix_microsec(uuid)
+  |> should.equal(1_712_910_566_000)
 }
 
 pub fn v7_can_validate_self_test() {

--- a/test/youid_test.gleam
+++ b/test/youid_test.gleam
@@ -1,4 +1,6 @@
 import gleam/bit_array
+import gleam/erlang/process
+import gleam/list
 import gleam/string
 import gleeunit
 import gleeunit/should
@@ -334,4 +336,17 @@ pub fn v7_can_validate_self_test() {
   uuid
   |> uuid.variant
   |> should.equal(uuid.Rfc4122)
+}
+
+pub fn v7_generation_sequence_test() {
+  let ids =
+    list.range(0, 1000)
+    |> list.map(fn(_) {
+      process.sleep(1)
+      uuid.v7_string()
+    })
+  let sorted = list.sort(ids, string.compare)
+
+  sorted
+  |> should.equal(ids)
 }


### PR DESCRIPTION
Performed basic validation and testing but may require more.

If you think it's reasonable for inclusion in this library as well, I can also make a followup PR for prefixed base32 encoding to implement [TypeID](https://github.com/jetify-com/typeid) support.