### PR TITLE
Fix test to use v3 instead of v5 for UUID

### DIFF
--- a/test/youid_test.gleam
+++ b/test/youid_test.gleam
@@ -223,7 +223,7 @@ pub fn v3_dns_namespace_test() {
 }
 
 pub fn v3_dont_crash_on_bad_name_test() {
-  uuid.v5(uuid.dns_uuid(), <<1:1>>)
+  uuid.v3(uuid.dns_uuid(), <<1:1>>)
   |> should.equal(Error(Nil))
 }
 


### PR DESCRIPTION
Typo?